### PR TITLE
bug fix: Fix dbt project loader when a directory is passed and dbt_packages are present

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,9 @@ def temp_complete_git_repo(temp_empty_git_repo):
         yaml.dump(project, f)
     dbt_profiles_file = dbt_dir / "profiles.yml"
     dbt_profiles_file.touch()
+    # Add a .venv directory
+    venv_dir = dbt_dir / ".venv"
+    venv_dir.mkdir()
     # Create a sql in models
     models_dir = dbt_dir / "models" / "test"
     models_dir.mkdir(parents=True)
@@ -106,5 +109,18 @@ def temp_complete_git_repo(temp_empty_git_repo):
     }
     with open(manifest_dir, "w") as f:
         json.dump(manifest_dict, f)
-
+    # Create dbt_packages directory and a package with a sql file and a dbt_project.yml file
+    dbt_packages_dir = dbt_dir / "dbt_packages" / "package"
+    dbt_packages_dir.mkdir(parents=True)
+    package_sql_file = dbt_packages_dir / "model.sql"
+    package_sql_file.touch()
+    with open(package_sql_file, "w") as f:
+        f.write("select id, value from table")
+    package_dbt_project_file = dbt_packages_dir / "dbt_project.yml"
+    package_dbt_project_file.touch()
+    package_project = {
+        "name": "package",
+    }
+    with open(package_dbt_project_file, "w") as f:
+        yaml.dump(package_project, f)
     return temp_empty_git_repo

--- a/tests/core/test_dbt_project_loader.py
+++ b/tests/core/test_dbt_project_loader.py
@@ -17,7 +17,7 @@ from dbt_opiner.dbt import DbtProjectLoader
         ),
         pytest.param(
             False,
-            [["dbt_project", "dbt_packages", "package", "model.sql"]],
+            [["dbt_project", "dbt_packages", "package", "macros", "macro.sql"]],
             id="One changed file, a model in a dbt package",
         ),
         pytest.param(

--- a/tests/core/test_dbt_project_loader.py
+++ b/tests/core/test_dbt_project_loader.py
@@ -1,0 +1,61 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from dbt_opiner.dbt import DbtProjectLoader
+
+
+@pytest.mark.parametrize(
+    "all_files, changed_files_parts",
+    [
+        pytest.param(True, None, id="all_files is True"),
+        pytest.param(
+            False,
+            [["dbt_project", "models", "test", "model.sql"]],
+            id="One changed file, a model in a dbt project",
+        ),
+        pytest.param(
+            False,
+            [["dbt_project", "dbt_packages", "package", "model.sql"]],
+            id="One changed file, a model in a dbt package",
+        ),
+        pytest.param(
+            False, [["dbt_project"]], id="Changed files is the dbt root directory"
+        ),
+    ],
+)
+def test_dbt_project_loader(temp_complete_git_repo, all_files, changed_files_parts):
+    os.chdir(temp_complete_git_repo)
+    changed_files = None
+    if changed_files_parts:
+        changed_files = [
+            temp_complete_git_repo.joinpath(*file_parts)
+            for file_parts in changed_files_parts
+        ]
+    loader = DbtProjectLoader()
+    projects = loader.initialize_dbt_projects(
+        all_files=all_files, changed_files=changed_files
+    )
+    assert len(projects) == 1
+    assert projects[0].dbt_project_file_path == temp_complete_git_repo.joinpath(
+        "dbt_project", "dbt_project.yml"
+    )
+
+
+@pytest.mark.parametrize(
+    "all_files, changed_files",
+    [
+        pytest.param(
+            True, [Path("some_file")], id="Both all_files and changed_files are passed"
+        ),
+        pytest.param(False, None, id="Neither all_files and changed_files are passed"),
+    ],
+)
+def test_dbt_project_loader_exceptions(
+    temp_complete_git_repo, all_files, changed_files
+):
+    os.chdir(temp_complete_git_repo)
+    loader = DbtProjectLoader()
+    with pytest.raises(ValueError):
+        loader.initialize_dbt_projects(all_files=all_files, changed_files=changed_files)


### PR DESCRIPTION
There was a bug in `DbtProjectLoader`.
When `DbtProjectLoader.initialize_dbt_projects(changed_files=list[Path])` received a directory, we were expanding the directory recursively finding all files inside the subdirectories.
When the directory is a dbt project root path, dbt packages files were included. Dbt packages have their own dbt_project.yml and we later ignore all dbt packages files. However, to do the ignore correctly we need to initialize the dbt project, to know the path to packages directory. 
This change fixes the incorrect assignment of dbt_project.yml, setting the file to the closest to the git repo.  This scenario is tested in cases number 3 and 4.

Also, improve the temp_complete_git_repo fixture.