### PR TITLE
feat: add csv log output support for audit option

### DIFF
--- a/dbt_opiner/cli.py
+++ b/dbt_opiner/cli.py
@@ -180,6 +180,7 @@ def lint(log_level, files, all_files, target, force_compile, no_ignore, output_f
 @main.command(help="Audit dbt project(s)")
 @common_options
 @click.option(
+    "-t",
     "--type",
     type=click.Choice(["general", "by_tag", "detailed", "all"], case_sensitive=False),
     default="general",
@@ -190,6 +191,12 @@ def lint(log_level, files, all_files, target, force_compile, no_ignore, output_f
             failed, and percentage of passed opinions.
     detailed: logs for every file with its detailed linting results.
     """,
+)
+@click.option(
+    "-f",
+    "--format",
+    type=click.Choice(["md", "csv"], case_sensitive=False),
+    default="md",
 )
 @click.option(
     "--dbt_project_dir",
@@ -215,7 +222,14 @@ def lint(log_level, files, all_files, target, force_compile, no_ignore, output_f
     help="If specified, a file to capture the audit results",
 )
 def audit(
-    log_level, type, dbt_project_dir, target, force_compile, no_ignore, output_file
+    log_level,
+    type,
+    format,
+    dbt_project_dir,
+    target,
+    force_compile,
+    no_ignore,
+    output_file,
 ):
     # Try to set a target from an environment variable
     # This is useful when things should run in CI
@@ -227,5 +241,5 @@ def audit(
     logger.add(sys.stdout, level=log_level.upper())
 
     entrypoint.audit(
-        type, dbt_project_dir, target, force_compile, no_ignore, output_file
+        type, format, dbt_project_dir, target, force_compile, no_ignore, output_file
     )

--- a/dbt_opiner/entrypoint.py
+++ b/dbt_opiner/entrypoint.py
@@ -16,7 +16,7 @@ def lint(
     force_compile: bool = False,
     no_ignore: bool = False,
     output_file: str = None,
-):
+) -> None:
     """Lint the dbt project using the dbt-opiner package.
 
     Args:
@@ -52,19 +52,21 @@ def lint(
 
 def audit(
     type: str,
+    format: str = "md",
     dbt_project_dir: str = None,
     target: str = None,
     force_compile: bool = False,
     no_ignore: bool = False,
     output_file: str = None,
-):
+) -> None:
     """Audit the dbt project using the dbt-opiner package.
 
     Args:
+        type: Type of audit to log. Defaults to all.
+        format: Format of the printed output md or csv. Defaults to md.
         dbt_project_dir: Directory of the dbt project to audit.
                          If not provided, all dbt projects in the git repository
                          will be audited.
-        type: Type of audit to log. Defaults to all.
         target: Target to run the dbt project. Defaults to None.
         force_compile: Flag to force compile the dbt project. Defaults to False
         no_ignore: Flag to ignore the no qa configurations. Defaults to False.
@@ -93,4 +95,4 @@ def audit(
         for file in merged_files:
             linter.lint_file(file)
 
-    linter.log_audit_and_exit(type=type, output_file=output_file)
+    linter.log_audit_and_exit(type=type, format=format, output_file=output_file)

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -96,12 +96,29 @@ def test_audit_project_error(runner, temp_complete_git_repo):
     assert "is not a dbt project" in result.output
 
 
-def test_audit_project(runner, temp_complete_git_repo):
+@pytest.mark.parametrize(
+    "format, expected",
+    [
+        pytest.param(
+            "md",
+            "dbt_project_name|severity|total_evaluated|passed|failed|percentage_passed",
+            id="md",
+        ),
+        pytest.param(
+            "csv",
+            "dbt_project_name,severity,total_evaluated,passed,failed,percentage_passed",
+            id="csv",
+        ),
+    ],
+)
+def test_audit_project(runner, temp_complete_git_repo, format, expected):
     os.chdir(temp_complete_git_repo)
     result = runner.invoke(
         main,
         [
             "audit",
+            "--format",
+            format,
             "--dbt_project_dir",
             "dbt_project",
             "--log-level",
@@ -109,9 +126,4 @@ def test_audit_project(runner, temp_complete_git_repo):
         ],
     )
     assert result.exit_code == 0
-    assert (
-        "dbt_project_name|severity|total_evaluated|passed|failed|percentage_passed".replace(
-            " ", ""
-        )
-        in result.output.replace(" ", "")
-    )
+    assert expected in result.output.replace(" ", "")

--- a/tests/core/test_linter.py
+++ b/tests/core/test_linter.py
@@ -89,7 +89,7 @@ def test_audit(caplog, mock_yamlfilehandler, result_type, expected):
     with patch("sys.exit") as mock_exit, patch.object(
         logger, "remove", lambda *args, **kwargs: None
     ):
-        linter.log_audit_and_exit(type=result_type)
+        linter.log_audit_and_exit(type=result_type, format="md")
 
         with caplog.at_level(logging.INFO):
             for expectation in expected:


### PR DESCRIPTION
Now you can log audit results either as a csv or as a md table.