### PR TITLE
fix: handle null patch_path in docs_yml_file_path

### DIFF
--- a/dbt_opiner/dbt.py
+++ b/dbt_opiner/dbt.py
@@ -307,7 +307,10 @@ class DbtNode:
 
     @property
     def docs_yml_file_path(self) -> str:
-        return self._node.get("patch_path", "").replace("://", "/")
+        patch_path = self._node.get("patch_path", "")
+        if patch_path:
+            return patch_path.replace("://", "/")
+        return ""
 
     @property
     def description(self) -> str:

--- a/dbt_opiner/dbt.py
+++ b/dbt_opiner/dbt.py
@@ -308,9 +308,7 @@ class DbtNode:
     @property
     def docs_yml_file_path(self) -> str:
         patch_path = self._node.get("patch_path", "")
-        if patch_path:
-            return patch_path.replace("://", "/")
-        return ""
+        return patch_path.replace("://", "/") if patch_path is not None else ""
 
     @property
     def description(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-opiner"
-version = "1.1.0"
+version = "1.1.1"
 description = "A tool to keep dbt projects on rails"
 authors=["Rodrigo Loredo <loredo.rod@gmail.com>"]
 readme = "README.md"

--- a/tests/core/test_dbt_node.py
+++ b/tests/core/test_dbt_node.py
@@ -188,3 +188,25 @@ from dbt_opiner import dbt
 def test_ast_extracted_columns(node_dict, expected_columns):
     node = dbt.DbtNode(node_dict, "duckdb")
     node.ast_extracted_columns == expected_columns
+
+
+# test logic in docs_yml_file_path property
+@pytest.mark.parametrize(
+    "node_dict, expected_path",
+    [
+        pytest.param(
+            {"patch_path": "billing_bigquery://models/some_path/_folder__models.yml"},
+            "billing_bigquery/models/some_path/_folder__models.yml",
+            id="Valid patch_path with expected format",
+        ),
+        pytest.param(
+            {"patch_path": None},
+            "",
+            id="None patch_path (e.g. for tests) returns empty string",
+        ),
+        pytest.param({}, "", id="Missing patch_path returns empty string"),
+    ],
+)
+def test_docs_yml_file_path(node_dict, expected_path):
+    node = dbt.DbtNode(node_dict)
+    assert node.docs_yml_file_path == expected_path


### PR DESCRIPTION
## Description
- test nodes have null in patch_path which was resulting in error: 
```
File "/opt/hostedtoolcache/Python/3.12.9/x64/lib/python3.12/site-packages/dbt_opiner/dbt.py", line 310, in docs_yml_file_path
    return self._node.get("patch_path", "").replace("://", "/")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'replace'
cat: dbt_opiner_lint_output.txt: No such file or directory
```